### PR TITLE
Fixing workflow concurrency for non-PR runs

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -14,7 +14,7 @@ on:
     paths: ['network_tools/**']
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/flutter.yml
+++ b/.github/workflows/flutter.yml
@@ -14,7 +14,7 @@ on:
     paths: ['network_tools_flutter/**']
 
 concurrency: 
-  group: ${{ github.head_ref }}
+  group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
   
 jobs:


### PR DESCRIPTION
github.head_ref is undefined for non-PR runs so adding github.run_id. See here reference https://docs.github.com/en/actions/using-jobs/using-concurrency#example-using-a-fallback-value