### PR TITLE
Prepare release 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log
 
+## 4.0.2
+1. Separated logs for example and library
+
 ## 4.0.1
-1. Fixex path problem for dart and flutter sdk
+1. Fixed path problem for dart and flutter sdk
 
 ## 4.0.0
 ### Breaking changes

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_tools
 description: Networking Tools library which can help you discover open ports, devices on subnet and many other things. 
-version: 4.0.1
+version: 4.0.2
 issue_tracker: https://github.com/osociety/network_tools/issues
 repository: https://github.com/osociety/network_tools
 


### PR DESCRIPTION
Fixes host scan examples and separates example logs from library logs.