### PR TITLE
Exposed tcpSrvRecordsList udpSrvRecordsList for network_tools_flutter

### DIFF
--- a/lib/network_tools.dart
+++ b/lib/network_tools.dart
@@ -11,6 +11,7 @@ import 'package:network_tools/src/services/arp_service.dart';
 export 'src/device_info/net_interface.dart';
 export 'src/device_info/vendor_table.dart';
 export 'src/host_scanner.dart';
+export 'src/mdns_scanner/list_of_srv_records.dart';
 export 'src/mdns_scanner/mdns_scanner.dart';
 export 'src/models/active_host.dart';
 export 'src/models/arp_data.dart';

--- a/lib/src/device_info/arp_table_helper.dart
+++ b/lib/src/device_info/arp_table_helper.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:logging/logging.dart';
 import 'package:network_tools/src/models/arp_data.dart';
+import 'package:universal_io/io.dart';
 
 class ARPTableHelper {
   static final arpLogger = Logger("arp-table-logger");

--- a/lib/src/device_info/net_interface.dart
+++ b/lib/src/device_info/net_interface.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'package:universal_io/io.dart';
 
 class NetInterface {
   NetInterface({

--- a/lib/src/device_info/vendor_table.dart
+++ b/lib/src/device_info/vendor_table.dart
@@ -1,11 +1,11 @@
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:csv/csv.dart';
 import 'package:http/http.dart' as http;
 import 'package:network_tools/network_tools.dart';
 import 'package:network_tools/src/network_tools_utils.dart';
 import 'package:path/path.dart' as p;
+import 'package:universal_io/io.dart';
 
 class VendorTable {
   static Map<dynamic, dynamic> _vendorTableMap = {};

--- a/lib/src/mdns_scanner/list_of_srv_records.dart
+++ b/lib/src/mdns_scanner/list_of_srv_records.dart
@@ -1,7 +1,7 @@
 /// Service record list that is including the protocol, mostly _tcp, _udp may
 /// not work
 List<String> tcpSrvRecordsList = [
-  '_uscan._tcp', // Any HP-compatible network scanners
+  '_scan._tcp', // Any HP-compatible network scanners
   '_uscans._tcp', // Any SSL/TLS-capable HP-compatible network scanners
   '_privet._tcp', // Any Google CloudPrint-capable printers or print services
   '_http-alt._tcp',

--- a/lib/src/mdns_scanner/list_of_srv_records.dart
+++ b/lib/src/mdns_scanner/list_of_srv_records.dart
@@ -1,7 +1,7 @@
 /// Service record list that is including the protocol, mostly _tcp, _udp may
 /// not work
 List<String> tcpSrvRecordsList = [
-  '_scan._tcp', // Any HP-compatible network scanners
+  '_uscan._tcp', // Any HP-compatible network scanners
   '_uscans._tcp', // Any SSL/TLS-capable HP-compatible network scanners
   '_privet._tcp', // Any Google CloudPrint-capable printers or print services
   '_http-alt._tcp',

--- a/lib/src/mdns_scanner/mdns_scanner.dart
+++ b/lib/src/mdns_scanner/mdns_scanner.dart
@@ -1,7 +1,6 @@
 import 'package:multicast_dns/multicast_dns.dart';
 import 'package:network_tools/network_tools.dart';
 import 'package:network_tools/src/mdns_scanner/get_srv_list_by_os/srv_list.dart';
-import 'package:network_tools/src/mdns_scanner/list_of_srv_records.dart';
 import 'package:network_tools/src/network_tools_utils.dart';
 import 'package:universal_io/io.dart';
 

--- a/lib/src/models/active_host.dart
+++ b/lib/src/models/active_host.dart
@@ -9,7 +9,7 @@ final _getIt = GetIt.instance;
 
 /// ActiveHost which implements comparable
 /// By default sort by hostId ascending
-class ActiveHost extends Comparable<ActiveHost> {
+class ActiveHost {
   ActiveHost({
     required this.internetAddress,
     this.openPorts = const [],
@@ -219,7 +219,6 @@ class ActiveHost extends Comparable<ActiveHost> {
   @override
   bool operator ==(Object o) => o is ActiveHost && address == o.address;
 
-  @override
   int compareTo(ActiveHost other) {
     return hostId.compareTo(other.hostId);
   }

--- a/lib/src/models/arp_data.dart
+++ b/lib/src/models/arp_data.dart
@@ -1,5 +1,5 @@
-import 'dart:io';
 import 'package:json_annotation/json_annotation.dart';
+import 'package:universal_io/io.dart';
 
 part 'arp_data.g.dart';
 

--- a/lib/src/models/open_port.dart
+++ b/lib/src/models/open_port.dart
@@ -1,9 +1,10 @@
 import 'package:json_annotation/json_annotation.dart';
+
 part 'open_port.g.dart';
 
 /// Represents open port for a target Address
 @JsonSerializable()
-class OpenPort extends Comparable<OpenPort> {
+class OpenPort {
   OpenPort(this.port, {this.isOpen = true});
   factory OpenPort.fromJson(Map<String, dynamic> json) =>
       _$OpenPortFromJson(json);
@@ -11,7 +12,6 @@ class OpenPort extends Comparable<OpenPort> {
   final int port;
   final bool isOpen;
 
-  @override
   int compareTo(OpenPort other) {
     return port.compareTo(other.port);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,36 +20,36 @@ funding:
   
 dependencies:
   # A dart csv to list converter.
-  csv: ^5.0.2
+  csv: ^5.1.1
   # Multi-platform network ping utility.
-  dart_ping: ^9.0.0
+  dart_ping: ^9.0.1
   # Defines the annotations used by json_serializable 
-  get_it: ^7.6.0
+  get_it: ^7.6.4
   # A composable, Future-based library for making HTTP requests.
-  http: ^1.1.0
+  http: ^1.1.2
   # Injectable is a convenient code generator for get_it. 
-  injectable: ^2.2.0
+  injectable: ^2.3.2
   # Defines the annotations used by json_serializable.
   json_annotation: ^4.8.1
   # Debugging and error logging.
   logging: ^1.2.0
   # Performing mDNS queries (e.g. Bonjour, Avahi).
-  multicast_dns: ^0.3.2+2
+  multicast_dns: ^0.3.2+6
   # A comprehensive, cross-platform path manipulation library for Dart.
-  path: ^1.8.3
+  path: ^1.9.0
   # Process run helpers
-  process_run: ^0.13.1
+  process_run: ^0.13.3+1
   # Yet another NoSQL persistent store database solution for single process io apps.
   sembast: ^3.5.0+1
   # Cross-platform 'dart:io' that works in all platforms.
-  universal_io: ^2.0.4
+  universal_io: ^2.2.2
   
 
 dev_dependencies:
   # Standalone generator and watcher for Dart 
-  build_runner: ^2.4.6
+  build_runner: ^2.4.7
   # A generator for injectable library.
-  injectable_generator: ^2.4.0
+  injectable_generator: ^2.4.1
   # Provides Dart Build System builders for handling JSON.
   json_serializable: ^6.7.1
   # Set of lint rules for Dart.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ issue_tracker: https://github.com/osociety/network_tools/issues
 repository: https://github.com/osociety/network_tools
 
 environment:
-  sdk: ">=2.17.6 <4.0.0"
+  sdk: ">=3.2.0 <4.0.0"
 
 topics:
   - network

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   # Performing mDNS queries (e.g. Bonjour, Avahi).
   multicast_dns: ^0.3.2+6
   # A comprehensive, cross-platform path manipulation library for Dart.
-  path: ^1.9.0
+  path: ^1.8.3
   # Process run helpers
   process_run: ^0.13.3+1
   # Yet another NoSQL persistent store database solution for single process io apps.


### PR DESCRIPTION
* Updated all packages
* min dart version to 3.2.0 as required by https://pub.dev/packages/http/changelog
* Exposed tcpSrvRecordsList udpSrvRecordsList for network_tools_flutter to support mdns search on ios using bonsoir.




Dart 3.0.0+ gave an error on `Comparable` so I have removed it, error:
`Removed The class 'Comparable' can't be extended outside of its library because it's an interface class.`

It looks like Wasm for Flutter is getting work on and maybe it will make our package even more usable on the browser with fewer limitations.
