### PR TITLE
index used for pinged should start from 0, otherwise it will trigger …

### DIFF
--- a/lib/src/services/impls/host_scanner_service_impl.dart
+++ b/lib/src/services/impls/host_scanner_service_impl.dart
@@ -86,12 +86,12 @@ class HostScannerServiceImpl extends HostScannerService {
 
     int i = 0;
     for (final Future<SendableActiveHost?> host in activeHostsFuture) {
-      i++;
       final SendableActiveHost? tempHost = await host;
 
       progressCallback?.call(
         (pinged[i] - firstHostId) * 100 / (lastValidSubnet - firstHostId),
       );
+      i++;
 
       if (tempHost == null) {
         continue;


### PR DESCRIPTION
index used for pinged should start from 0, otherwise it will trigger a RangeError. So I move i++ down to the below of pinged[i].

For example, when you running the below code, you will get `RangeError (RangeError (length): Invalid value: Not in inclusive range 0..9: 10)`

And after fix, it will finish with no error.

```
import 'package:network_tools/network_tools.dart';

Future<void> main() async {
  await configureNetworkTools('build', enableDebugging: true);
   String address = '10.3.0.10';

  final String subnet = address.substring(0, address.lastIndexOf('.'));
  final stream = HostScannerService.instance.getAllPingableDevices(subnet, firstHostId: 1, lastHostId: 9,
      progressCallback: (progress) {
    print('Progress for host discovery : $progress');
  });

  stream.listen((host) {
    print('Found device: $host');
  }, onDone: () {
    print('Scan completed');
  }); 
}
```
