### PR TITLE
Fix: Use PingEvent (dart_ping v10)

### DIFF
--- a/lib/src/models/active_host.dart
+++ b/lib/src/models/active_host.dart
@@ -12,7 +12,7 @@ class ActiveHost {
     required this.internetAddress,
     this.openPorts = const [],
     String? macAddress,
-    PingData? pingData,
+    PingEvent? pingData,
     MdnsInfo? mdnsInfoVar,
   }) {
     _macAddress = macAddress;
@@ -58,7 +58,7 @@ class ActiveHost {
     required String address,
     String? macAddress,
     List<OpenPort> openPorts = const [],
-    PingData? pingData,
+    PingEvent? pingData,
     MdnsInfo? mdnsInfo,
   }) {
     final InternetAddress? internetAddressTemp = InternetAddress.tryParse(
@@ -108,7 +108,7 @@ class ActiveHost {
   /// not follow any internet protocol property
   late Future<String?> hostName;
   late String weirdHostName;
-  late final PingData _pingData;
+  late final PingEvent? _pingData;
 
   /// Mdns information of this device
   late Future<MdnsInfo?> mdnsInfo;
@@ -134,26 +134,29 @@ class ActiveHost {
   /// This value **can change after the object got created** since getting
   /// host name of device is running async function.
   late Future<String> deviceName;
-  PingData get pingData => _pingData;
-  Duration? get responseTime => _pingData.response?.time;
+  PingEvent? get pingData => _pingData;
+  Duration? get responseTime {
+    final event = _pingData;
+    if (event is PingResponse) return event.time;
+    return null;
+  }
+
   String get address => internetAddress.address;
 
-  static PingData getPingData(String host) {
+  static PingEvent? getPingData(String host) {
     const int timeoutInSeconds = 1;
-
-    PingData tempPingData = const PingData();
+    PingEvent? tempPingData;
 
     Ping(
       host,
       count: 1,
       timeout: timeoutInSeconds,
       forceCodepage: Platform.isWindows,
-    ).stream.listen((pingData) {
-      final PingResponse? response = pingData.response;
-      if (response != null) {
-        final Duration? time = response.time;
+    ).stream.listen((event) {
+      if (event is PingResponse) {
+        final Duration? time = event.time;
         if (time != null) {
-          tempPingData = pingData;
+          tempPingData = event;
         }
       }
     });

--- a/lib/src/models/sendable_active_host.dart
+++ b/lib/src/models/sendable_active_host.dart
@@ -5,6 +5,6 @@ import 'package:network_tools/network_tools.dart';
 class SendableActiveHost {
   SendableActiveHost(this.address, {this.pingData, this.openPorts = const []});
   final String address;
-  final PingData? pingData;
+  final PingEvent? pingData;
   List<OpenPort> openPorts;
 }

--- a/lib/src/services/impls/host_scanner_service_impl.dart
+++ b/lib/src/services/impls/host_scanner_service_impl.dart
@@ -109,29 +109,23 @@ class HostScannerServiceImpl extends HostScannerService {
   }) async {
     SendableActiveHost? tempSendableActivateHost;
 
-    await for (final PingData pingData in Ping(
+    await for (final PingEvent event in Ping(
       host,
       count: 1,
       timeout: timeoutInSeconds,
       forceCodepage: Platform.isWindows,
     ).stream) {
-      final PingResponse? response = pingData.response;
-      final PingError? pingError = pingData.error;
-      if (response != null) {
+      if (event is PingResponse) {
         // Check if ping succeeded
-        if (pingError == null) {
-          final Duration? time = response.time;
-          if (time != null) {
-            logger.fine("Pingable device found: $host");
-            tempSendableActivateHost = SendableActiveHost(
-              host,
-              pingData: pingData,
-            );
-          } else {
-            logger.fine("Non pingable device found: $host");
-          }
+        final Duration? time = event.time;
+        if (time != null) {
+          logger.fine("Pingable device found: $host");
+          tempSendableActivateHost = SendableActiveHost(host, pingData: event);
+        } else {
+          logger.fine("Non pingable device found: $host");
         }
       }
+
       if (tempSendableActivateHost == null) {
         // Check if it's there in arp table
 
@@ -139,10 +133,7 @@ class HostScannerServiceImpl extends HostScannerService {
 
         if (data != null) {
           logger.fine("Successfully fetched arp entry for $host as $data");
-          tempSendableActivateHost = SendableActiveHost(
-            host,
-            pingData: pingData,
-          );
+          tempSendableActivateHost = SendableActiveHost(host, pingData: event);
         } else {
           logger.fine("Problem in fetching arp entry for $host");
         }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   # A dart csv to list converter.
   csv: ^8.0.0
   # Multi-platform network ping utility.
-  dart_ping: ^9.0.1
+  dart_ping: ">=9.0.1 <11.0.0"
   # Drift is a reactive persistence library for Flutter and Dart, built on top of SQLite.
   drift: ^2.34.0
   # Service locator


### PR DESCRIPTION
Replace PingData usages with PingEvent and handle PingResponse/PingError variants to match dart_ping v10 API. Runs tests and fixes analyzer errors.