### PR TITLE
Fix: Bundle sqlite native libs on mobile (fixes #247)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,10 @@ dependencies:
   process_run: ^1.3.3
   # sqlite3 is a pure Dart implementation of SQLite.
   sqlite3: ">=2.8.0 <4.0.0"
+  # Include native sqlite3 libraries for mobile platforms (Android/iOS)
+  # so apps using this package do not crash when sqlite native lib is missing.
+  # See: https://pub.dev/packages/sqlite3_flutter_libs
+  sqlite3_flutter_libs: ">=0.5.0 <2.0.0"
   # Cross-platform 'dart:io' that works in all platforms.
   universal_io: ^2.3.1
   


### PR DESCRIPTION
Add sqlite3_flutter_libs as a dependency so native sqlite libraries (libsqlite3.so / dylib) are bundled on Android and iOS. This prevents runtime crashes on devices where the native sqlite library is missing (see #247).